### PR TITLE
reset table ids on reset

### DIFF
--- a/app/libs/bugm_host.rb
+++ b/app/libs/bugm_host.rb
@@ -20,7 +20,12 @@ class BugmHost
 
     def reset_postgres
       tables = %w(Tracker User Offer Escrow Position Amendment Contract Event)
-      tables.each {|el| Object.const_get(el).destroy_all}
+      tables.each {|el| 
+        Object.const_get(el).destroy_all
+        # reset the IDs
+        sql = "TRUNCATE TABLE #{Object.const_get(el).table_name} RESTART IDENTITY;"
+        ActiveRecord::Base.connection.execute(sql)
+      }
       BugmTime.clear_offset
       PayproCmd::Create.new({})
       UserCmd::Create.new({email: 'admin@bugmark.net', password: 'bugmark'}).project


### PR DESCRIPTION
Hi @andyl 

This pull request will reset the ID upon `BugmHost.reset`

The fact that ids in tables keep increasing after resetting the exchange has always bothered me.